### PR TITLE
Add Rust to CI.

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -21,8 +21,8 @@ sudo apt-get install -qq -y \
    openjdk-8-jdk-headless \
    perl \
    php5-cli \
-   ruby
-# rust is broken
+   ruby \
+   rustc
 
 # update-alternatives nonsense to force gcc-6
 sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 100


### PR DESCRIPTION
This seems to just work, because of the update from Rust 1.15.1 to 1.17.0,
(see https://travis-ci.org/MaloJaffre/camisole/jobs/295996095#L837).

Related to #24 and prologin/site-issues#35.