### PR TITLE
languages: add scala support

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -24,7 +24,8 @@ sudo apt-get install -qq -y \
    php-cli \
    ruby \
    rustc \
-   swi-prolog-nox
+   swi-prolog-nox \
+   scala
 
 # dlang
 wget -O /tmp/dmd_2.078.2-0_amd64.deb http://downloads.dlang.org/releases/2.x/2.078.2/dmd_2.078.2-0_amd64.deb

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -24,8 +24,8 @@ sudo apt-get install -qq -y \
    php-cli \
    ruby \
    rustc \
-   swi-prolog-nox \
-   scala
+   scala \
+   swi-prolog-nox 
 
 # dlang
 wget -O /tmp/dmd_2.078.2-0_amd64.deb http://downloads.dlang.org/releases/2.x/2.078.2/dmd_2.078.2-0_amd64.deb

--- a/README.rst
+++ b/README.rst
@@ -28,8 +28,8 @@ Features
 --------
 
 - Built-in support for a wide variety of languages, including Ada, C, C#, C++,
-  Haskell, Java, JavaScript, Lua, OCaml, Pascal, Perl, PHP, Python, Ruby,
-  Scheme, Scala…
+  Haskell, Java, JavaScript, Lua, OCaml, Pascal, Perl, PHP, Python, Ruby, Scala
+  Scheme…
 - Isolation: *camisole* runs both the compilation and execution stages in a
   **sandboxed** environment provided by isolate_
 - Limitation of resources (time, wall-time, memory…)

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Features
 
 - Built-in support for a wide variety of languages, including Ada, C, C#, C++,
   Haskell, Java, JavaScript, Lua, OCaml, Pascal, Perl, PHP, Python, Ruby,
-  Scheme…
+  Scheme, Scala…
 - Isolation: *camisole* runs both the compilation and execution stages in a
   **sandboxed** environment provided by isolate_
 - Limitation of resources (time, wall-time, memory…)

--- a/camisole/languages/__init__.py
+++ b/camisole/languages/__init__.py
@@ -56,4 +56,5 @@ __all__ = [
     'ruby',
     'rust',
     'scheme',
+    'scala'
 ]

--- a/camisole/languages/__init__.py
+++ b/camisole/languages/__init__.py
@@ -55,6 +55,6 @@ __all__ = [
     'python',
     'ruby',
     'rust',
+    'scala',
     'scheme',
-    'scala'
 ]

--- a/camisole/languages/scala.py
+++ b/camisole/languages/scala.py
@@ -1,0 +1,9 @@
+from camisole.languages.java import Java
+from camisole.models import Program
+
+class Scala(Java):
+    source_ext = '.scala'
+    compiled_ext = '.class'
+    compiler = Program('scalac',opts=['-encoding', 'UTF-8'],env={'LANG': 'en_US.UTF-8'}, version_opt='-version')
+    interpreter = Program('scala', version_opt='-version')
+    reference_source = r'object Main extends App {println("42");}'

--- a/camisole/languages/scala.py
+++ b/camisole/languages/scala.py
@@ -1,9 +1,11 @@
 from camisole.languages.java import Java
 from camisole.models import Program
 
+
 class Scala(Java):
     source_ext = '.scala'
     compiled_ext = '.class'
-    compiler = Program('scalac',opts=['-encoding', 'UTF-8'],env={'LANG': 'en_US.UTF-8'}, version_opt='-version')
+    compiler = Program('scalac', opts=[
+                       '-encoding', 'UTF-8'], env={'LANG': 'en_US.UTF-8'}, version_opt='-version')
     interpreter = Program('scala', version_opt='-version')
-    reference_source = r'object Main extends App {println("42");}'
+    reference_source = r'object Main extends App { println("42"); }'


### PR DESCRIPTION
As a Scala lover, I would love to add the support for Scala, so I did and hope it would help.

##  Implementation

As Scala is build using the JVM, I only extended the existent Java class and made some adjustments to build Scala codes.
Furthermore, the current implementation use the same decompilation process (using `javap`) to find the main function, thus, Scala codes using `DelayedInit` or `App` traits just work out of the box.

I also added the requirements (for Debian) in the Travis-CI config.