### PR TITLE
Languages: add LLVM asm support

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -25,7 +25,7 @@ sudo apt-get install -qq -y \
    ruby \
    rustc \
    swi-prolog-nox \
-   llvm-8
+   llvm-8 clang-8 
 
 # dlang
 wget -O /tmp/dmd_2.078.2-0_amd64.deb http://downloads.dlang.org/releases/2.x/2.078.2/dmd_2.078.2-0_amd64.deb

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -24,7 +24,8 @@ sudo apt-get install -qq -y \
    php-cli \
    ruby \
    rustc \
-   swi-prolog-nox
+   swi-prolog-nox \
+   llvm-8
 
 # dlang
 wget -O /tmp/dmd_2.078.2-0_amd64.deb http://downloads.dlang.org/releases/2.x/2.078.2/dmd_2.078.2-0_amd64.deb

--- a/camisole/languages/__init__.py
+++ b/camisole/languages/__init__.py
@@ -56,4 +56,5 @@ __all__ = [
     'ruby',
     'rust',
     'scheme',
+    'llvmasm'
 ]

--- a/camisole/languages/llvmasm.py
+++ b/camisole/languages/llvmasm.py
@@ -1,0 +1,15 @@
+from camisole.models import Lang, Program
+
+class LLVMAsm(Lang):
+    source_ext = '.ll'
+    interpreter = Program('lli-8')
+    reference_source = """@str42 = internal constant [4 x i8] c"42\0A\00"
+
+declare i32 @printf(i8*, ...)
+
+define i32 @main(...) nounwind {
+entry:
+  %strptr = getelementptr [4 x i8], [4 x i8]* @str42, i32 0, i32 0
+  call i32 (i8*, ...) @printf( i8* %strptr ) nounwind
+  ret i32 0
+}"""

--- a/camisole/languages/llvmasm.py
+++ b/camisole/languages/llvmasm.py
@@ -2,8 +2,10 @@ from camisole.models import Lang, Program
 
 class LLVMAsm(Lang):
     source_ext = '.ll'
+    compiler = Program('clang-8')
     interpreter = Program('lli-8')
-    reference_source = """@str42 = internal constant [4 x i8] c"42\0A\00"
+    reference_source = r"""
+@str42 = internal constant [4 x i8] c"42\0A\00"
 
 declare i32 @printf(i8*, ...)
 

--- a/camisole/languages/llvmasm.py
+++ b/camisole/languages/llvmasm.py
@@ -2,8 +2,12 @@ from camisole.models import Lang, Program
 
 class LLVMAsm(Lang):
     source_ext = '.ll'
-    compiler = Program('clang-8')
-    interpreter = Program('lli-8')
+    compiler = Program('clang-8', opts=[ # Statically compile the program.
+        '-x', 'ir',                      # Force the target language to be LLVM AS.
+        '-Wno-override-module'           # Because the source file might lack the target module,
+                                         # we don't want clang to complain about it.
+    ])
+    interpreter = Program('lli-8')       # JIT compiler.
     reference_source = r"""
 @str42 = internal constant [4 x i8] c"42\0A\00"
 


### PR DESCRIPTION
Add support for the IR assembly language of LLVM.

The language support is implemented as an interpreted language, as the `llvm-8` package (which I've added to the travis dependencies) gives an interpreter.