### PR TITLE
Optimisation level 3 for the Rust compiler

### DIFF
--- a/camisole/languages/rust.py
+++ b/camisole/languages/rust.py
@@ -3,5 +3,5 @@ from camisole.models import Lang, Program
 
 class Rust(Lang):
     source_ext = '.rs'
-    compiler = Program('rustc', opts=['-W', 'warnings', '-C", "opt-level=3'])
+    compiler = Program('rustc', opts=['-W', 'warnings', '-C', 'opt-level=3'])
     reference_source = r'fn main() { println!("42"); }'

--- a/camisole/languages/rust.py
+++ b/camisole/languages/rust.py
@@ -3,5 +3,5 @@ from camisole.models import Lang, Program
 
 class Rust(Lang):
     source_ext = '.rs'
-    compiler = Program('rustc', opts=['-W', 'warnings', '-C opt-level=3'])
+    compiler = Program('rustc', opts=['-W', 'warnings', '-C", "opt-level=3'])
     reference_source = r'fn main() { println!("42"); }'

--- a/camisole/languages/rust.py
+++ b/camisole/languages/rust.py
@@ -3,5 +3,5 @@ from camisole.models import Lang, Program
 
 class Rust(Lang):
     source_ext = '.rs'
-    compiler = Program('rustc', opts=['-W', 'warnings', '-O'])
+    compiler = Program('rustc', opts=['-W', 'warnings', '-C opt-level=3'])
     reference_source = r'fn main() { println!("42"); }'


### PR DESCRIPTION
Currently, the `-O` compiler flag is present, which is an alias for `-C opt-level=2`. `-C opt-level=3` can be used instead for greater execution speed. 

Optimization level 3 is considered safe, as it is used with the `--release` cargo flag.